### PR TITLE
Upgrade simple-icons to 11.8.0

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -53,4 +53,4 @@ jobs:
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: poetry run python scripts/auto-update.py
+        run: poetry run python -m scripts.auto-update

--- a/scripts/auto-update.py
+++ b/scripts/auto-update.py
@@ -7,7 +7,7 @@ import requests
 import semantic_version
 import git
 
-from build_package import build
+from scripts.build_package import build
 
 current_si_pkg = None
 with open(Path("vendor", "simple-icons", "package.json"), "r") as f:

--- a/scripts/auto-update.py
+++ b/scripts/auto-update.py
@@ -35,7 +35,7 @@ if new_si_version <= current_si_version:
 repo = git.Repo(os.getcwd())
 si_submodule = repo.submodule("vendor/simple-icons")
 si_submodule_repo = si_submodule.module()
-si_submodule_repo.remotes.origin.fetch()
+si_submodule_repo.remotes.origin.fetch("--tags")
 
 si_submodule_repo.git.checkout(new_si_version_str)
 print(f"Checked out branch {new_si_version_str} of simple-icons in submodule.")

--- a/scripts/auto-update.py
+++ b/scripts/auto-update.py
@@ -22,7 +22,7 @@ new_si_version_str = new_si_pkg["dist-tags"]["latest"]
 new_si_version = semantic_version.Version(new_si_pkg["dist-tags"]["latest"])
 
 # do not attempt to update if major versions do not match
-#if current_si_version.major != new_si_version.major:
+# if current_si_version.major != new_si_version.major:
 #    print("Next update is major, exiting.")
 #    exit(1)
 

--- a/scripts/auto-update.py
+++ b/scripts/auto-update.py
@@ -7,7 +7,7 @@ import requests
 import semantic_version
 import git
 
-from scripts.build_package import build
+from build_package import build
 
 current_si_pkg = None
 with open(Path("vendor", "simple-icons", "package.json"), "r") as f:
@@ -22,9 +22,9 @@ new_si_version_str = new_si_pkg["dist-tags"]["latest"]
 new_si_version = semantic_version.Version(new_si_pkg["dist-tags"]["latest"])
 
 # do not attempt to update if major versions do not match
-if current_si_version.major != new_si_version.major:
-    print("Next update is major, exiting.")
-    exit(1)
+#if current_si_version.major != new_si_version.major:
+#    print("Next update is major, exiting.")
+#    exit(1)
 
 # version is lower or equal - exit
 if new_si_version <= current_si_version:
@@ -35,7 +35,7 @@ if new_si_version <= current_si_version:
 repo = git.Repo(os.getcwd())
 si_submodule = repo.submodule("vendor/simple-icons")
 si_submodule_repo = si_submodule.module()
-si_submodule_repo.remotes.origin.fetch("--tags")
+si_submodule_repo.remotes.origin.fetch()
 
 si_submodule_repo.git.checkout(new_si_version_str)
 print(f"Checked out branch {new_si_version_str} of simple-icons in submodule.")

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 from simpleicons.icon import License
-from utils import get_icon_slug, title_to_slug
+from scripts.utils import get_icon_slug, title_to_slug
 
 simpleicons_vendor_dir = Path("vendor", "simple-icons")
 simpleicons_source_dir = simpleicons_vendor_dir / "icons"

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 from simpleicons.icon import License
-from scripts.utils import get_icon_slug, title_to_slug
+from utils import get_icon_slug, title_to_slug
 
 simpleicons_vendor_dir = Path("vendor", "simple-icons")
 simpleicons_source_dir = simpleicons_vendor_dir / "icons"


### PR DESCRIPTION
The auto-update workflow has a protection against major updates. Nonetheless there is no issue in moving from current version (7.21.0) to 11.8.0.

This PR: 
- temporarily comments the major version check
- fixes a path import issue with calling scripts.autor-update